### PR TITLE
[Misc] Corrected Repo URL for the UI Sources XWiki Page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <scm>
         <connection>scm:git:git://github.com/xwiki-contrib/application-ai-llm.git</connection>
         <developerConnection>scm:git:git@github.com:xwiki-contrib/application-ai-llm.git</developerConnection>
-        <url>https://github.com/xwiki-contrib/application-ai-llm</url>
+        <url>https://github.com/xwiki-contrib/application-ai-llm/tree/main</url>
         <tag>HEAD</tag>
     </scm>
     <developers>


### PR DESCRIPTION
Currently, on the page [LLM App - XWiki](https://extensions.xwiki.org/xwiki/bin/view/Extension/LLM%20Application/), if we click on the `Sources` button (next to the `Download` button), the URL we get is: https://github.com/xwiki-contrib/application-ai-llm/application-llm-ui

Which returns a 404 because we need to specify a GitHub branch to navigate to. This PR solves the minor issue.