### PR TITLE
Add provider-level query parameter support for OpenAI-compatible endpoints

### DIFF
--- a/application-ai-llm-models/application-ai-llm-models-api/src/main/java/org/xwiki/contrib/llm/GPTAPIConfig.java
+++ b/application-ai-llm-models/application-ai-llm-models-api/src/main/java/org/xwiki/contrib/llm/GPTAPIConfig.java
@@ -29,6 +29,7 @@ public class GPTAPIConfig
 {
     private String name;
     private String url;
+    private String queryParameters;
     private String token;
     private boolean canStream;
 
@@ -41,6 +42,7 @@ public class GPTAPIConfig
     {
         this.name = (String) properties.get("Name");
         this.url = (String) properties.get("url");
+        this.queryParameters = (String) properties.get("queryParameters");
         this.token = (String) properties.get("token");
         Integer requestMode = (Integer) properties.get("Requestmode");
         this.canStream = requestMode != null && requestMode == 1;
@@ -80,6 +82,14 @@ public class GPTAPIConfig
     }
 
     /**
+     * @return The optional query parameters that are appended to each provider request.
+     */
+    public String getQueryParameters()
+    {
+        return queryParameters;
+    }
+
+    /**
      * @return true if the configuration can use a streaming API, else false.
      */
     public Boolean getCanStream()
@@ -95,6 +105,7 @@ public class GPTAPIConfig
     {
         String res = "Name : " + name;
         res += " URL : " + url;
+        res += " queryParameters : " + queryParameters;
         res += " Token : " + token;
         res += " canStream : " + canStream;
         return res;

--- a/application-ai-llm-models/application-ai-llm-models-api/src/main/java/org/xwiki/contrib/llm/internal/RequestHelper.java
+++ b/application-ai-llm-models/application-ai-llm-models-api/src/main/java/org/xwiki/contrib/llm/internal/RequestHelper.java
@@ -24,10 +24,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -138,7 +140,7 @@ public class RequestHelper
     private <T> HttpRequest prepareRequest(String path, GPTAPIConfig config, T body) throws IOException
     {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
-            .uri(URI.create(config.getURL() + path))
+            .uri(buildEndpointURI(config, path))
             .header("Authorization", BEARER + config.getToken())
             .header("Accept", APPLICATION_JSON)
             .header("Content-Type", APPLICATION_JSON)
@@ -151,5 +153,39 @@ public class RequestHelper
         }
 
         return builder.build();
+    }
+
+    private URI buildEndpointURI(GPTAPIConfig config, String path) throws IOException
+    {
+        try {
+            URI baseURI = URI.create(config.getURL());
+            String basePath = StringUtils.defaultString(baseURI.getPath());
+            if (!basePath.endsWith("/")) {
+                basePath += '/';
+            }
+
+            String endpointPath = StringUtils.removeStart(path, "/");
+            String query = joinQueryParts(baseURI.getQuery(), config.getQueryParameters());
+
+            return new URI(baseURI.getScheme(), baseURI.getAuthority(), basePath + endpointPath, query,
+                baseURI.getFragment());
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            throw new IOException("Invalid AI provider URL configuration", e);
+        }
+    }
+
+    private String joinQueryParts(String... queryParts)
+    {
+        StringJoiner joiner = new StringJoiner("&");
+        for (String queryPart : queryParts) {
+            String normalizedQuery = StringUtils.trimToEmpty(queryPart);
+            normalizedQuery = StringUtils.removeStart(normalizedQuery, "?");
+            if (StringUtils.isNotEmpty(normalizedQuery)) {
+                joiner.add(normalizedQuery);
+            }
+        }
+
+        String mergedQuery = joiner.toString();
+        return StringUtils.isEmpty(mergedQuery) ? null : mergedQuery;
     }
 }

--- a/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/AIConfigClass.xml
+++ b/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/AIConfigClass.xml
@@ -91,6 +91,20 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
     </token>
+    <queryParameters>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint>Optional query parameters applied to every request</hint>
+      <name>queryParameters</name>
+      <number>7</number>
+      <picker>1</picker>
+      <prettyName>AI Code Server Query Parameters</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </queryParameters>
     <url>
       <customDisplay/>
       <disabled>0</disabled>

--- a/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/AIConfigSheet.xml
+++ b/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/AIConfigSheet.xml
@@ -69,8 +69,8 @@
   #set ($deleteURL = $configDoc.getURL('objectremove', "form_token=$!{services.csrf.getToken()}&amp;classname=${escapetool.url($configClassName)}&amp;classid=${serverObject.number}&amp;xredirect=${escapetool.url($redirect)}"))
 
 {{box}}
-|=$services.localization.render('llm.config.name')|=$services.localization.render('llm.config.url')|=$services.localization.render('llm.config.token')|=$services.localization.render('llm.config.requestmode')|=$services.localization.render('llm.config.delete')
-|$serverObject.display('Name', 'edit') |$serverObject.display('url', 'edit')|$serverObject.display('token', 'edit')|$serverObject.display('Requestmode', 'edit')|[[image:icon:cross&gt;&gt;path:$deleteURL]]
+|=$services.localization.render('llm.config.name')|=$services.localization.render('llm.config.url')|=$services.localization.render('llm.config.queryParameters')|=$services.localization.render('llm.config.token')|=$services.localization.render('llm.config.requestmode')|=$services.localization.render('llm.config.delete')
+|$serverObject.display('Name', 'edit') |$serverObject.display('url', 'edit')|$serverObject.display('queryParameters', 'edit')|$serverObject.display('token', 'edit')|$serverObject.display('Requestmode', 'edit')|[[image:icon:cross&gt;&gt;path:$deleteURL]]
 {{/box}}
 
 #end

--- a/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/Translation.xml
+++ b/application-ai-llm-models/application-ai-llm-models-ui/src/main/resources/AI/Code/Translation.xml
@@ -58,10 +58,12 @@ llm.ui.featureMenuPlaceholder=Select a Prompt
 llm.ui.applicationsPanelEntryLabel=LLM Application
 llm.config.label=LLM Assistant Configuration
 llm.config.label.hint=Configuration for the LLM application, need at least one configuration with one model and the \
-    associated URL prefix/token to work. The URL prefix should allow access to /chat/completions, and /models when the \
+  associated URL prefix/token to work. The URL prefix should allow access to /chat/completions, and /models when the \
     configured list of models is empty. For example, if the prefix looks like http://example.url.com/ then http://example.url.com/models and http://example.url.com/chat/completions should be accessible.
+  You can optionally configure query parameters that are appended to each request, e.g. api-version=2025-04-01-preview.
 llm.config.name=Server Name
 llm.config.url=URL prefix
+llm.config.queryParameters=Query parameters
 llm.config.token=Token
 llm.config.configfile=Chat models
 llm.config.embeddingModels=Embedding models


### PR DESCRIPTION
This PR improves endpoint handling for OpenAI-compatible providers that require mandatory query parameters (for example Azure Foundry with api-version).

Changes included:

Added an optional query parameters field to the AI provider configuration
Updated request URL construction to safely combine base URL, endpoint path, and query parameters
Extended the configuration UI to expose the new field
Updated localization text and configuration hints
Result:
Providers that require fixed query parameters on every call now work for both model listing and chat completion requests, while staying backward-compatible with existing configurations.